### PR TITLE
Temp dir workaround

### DIFF
--- a/support/lib/util.py
+++ b/support/lib/util.py
@@ -5,21 +5,9 @@ class UserError(Exception):
 	pass
 
 
-def _temp_dir_is_on_same_mount_point():
-	tempdir_stat = os.stat(tempfile.gettempdir())
-	working_dir_stat = os.stat('.')
-	
-	return tempdir_stat.st_dev == working_dir_stat.st_dev
-
-
 @contextlib.contextmanager
 def TemporaryDirectory():
-	if _temp_dir_is_on_same_mount_point():
-		dir = None
-	else:
-		dir = '.'
-	
-	dir = tempfile.mkdtemp(dir = dir, prefix = '.tmp_')
+	dir = tempfile.mkdtemp()
 	
 	try:
 		yield dir


### PR DESCRIPTION
Currently, on setups where the project dir is on a different file system as the system temporary directory, a temporary directory is instead created on the project dir. This is not very nice.

With this change, we still create temporary files in the system temporary directory but copy instead of move files from and to the temporary directory, if necessary, which solves the problems.
